### PR TITLE
Addresses caching bug that results in blank page

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,9 +35,14 @@ exports.render = function(str, options, fn) {
 
   try {
     var path = options.filename;
-    var tokens = options.cache
-      ? exports.cache[path] || (exports.cache[path] = marked.lexer(str, opts))
-      : marked.lexer(str, opts);
+    if (options.cache) { // make cannibalizeable tokens
+      exports.cache[path] = exports.cache[path] 
+        ? exports.cache[path] : marked.lexer(str, opts);
+      var tokens = JSON.parse(JSON.stringify(exports.cache[path]));
+      tokens.links = typeof tokens.links === "undefined" ? {} : tokens.links;
+    } else {
+      var tokens =  marked.lexer(str, opts);
+    }
     fn(null, marked.parser(tokens, opts));
   } catch (err) {
     fn(err);


### PR DESCRIPTION
https://github.com/jaredhanson/marked-engine/issues/3

marked.parser cannibalized the tokens object, which references the one in the cache. This is a little more verbose, but git is a line by line versioning system... leaning on the side of more lines is desirable. Plus it fixes the bug.